### PR TITLE
performance optimization in write_n_items

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-concurrent-col"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A core data structure with a focus to enable high performance, possibly lock-free, concurrent collections using a PinnedVec as the underlying storage."
@@ -10,9 +10,9 @@ keywords = ["concurrency", "bag", "data-structures", "atomic", "lock-free"]
 categories = ["data-structures", "concurrency", "rust-patterns"]
 
 [dependencies]
-orx-fixed-vec = "2.9"
-orx-pinned-vec = "2.9"
-orx-split-vec = "2.11"
+orx-fixed-vec = "2.11"
+orx-pinned-vec = "2.11"
+orx-split-vec = "2.13"
 
 [dev-dependencies]
 test-case = "3.3.1"

--- a/src/common_traits/debug.rs
+++ b/src/common_traits/debug.rs
@@ -4,6 +4,7 @@ use std::fmt::Debug;
 
 impl<T, P, S> Debug for PinnedConcurrentCol<T, P, S>
 where
+    T: Default,
     P: PinnedVec<T>,
     S: ConcurrentState + Debug,
 {

--- a/src/new.rs
+++ b/src/new.rs
@@ -4,6 +4,7 @@ use orx_split_vec::{Doubling, Linear, Recursive, SplitVec};
 
 impl<T, S> PinnedConcurrentCol<T, SplitVec<T, Doubling>, S>
 where
+    T: Default,
     S: ConcurrentState,
 {
     /// Creates a new concurrent bag by creating and wrapping up a new `SplitVec<T, Doubling>` as the underlying storage.
@@ -14,6 +15,7 @@ where
 
 impl<T, S> PinnedConcurrentCol<T, SplitVec<T, Recursive>, S>
 where
+    T: Default,
     S: ConcurrentState,
 {
     /// Creates a new concurrent bag by creating and wrapping up a new `SplitVec<T, Recursive>` as the underlying storage.
@@ -24,6 +26,7 @@ where
 
 impl<T, S> PinnedConcurrentCol<T, SplitVec<T, Linear>, S>
 where
+    T: Default,
     S: ConcurrentState,
 {
     /// Creates a new concurrent bag by creating and wrapping up a new `SplitVec<T, Linear>` as the underlying storage.
@@ -49,6 +52,7 @@ where
 
 impl<T, S> PinnedConcurrentCol<T, FixedVec<T>, S>
 where
+    T: Default,
     S: ConcurrentState,
 {
     /// Creates a new concurrent bag by creating and wrapping up a new `FixedVec<T>` as the underlying storage.
@@ -68,6 +72,7 @@ where
 // from
 impl<T, P, S> From<P> for PinnedConcurrentCol<T, P, S>
 where
+    T: Default,
     P: PinnedVec<T>,
     S: ConcurrentState,
 {

--- a/src/state.rs
+++ b/src/state.rs
@@ -10,7 +10,9 @@ where
     fn zero_memory(&self) -> bool;
 
     /// Creates a new state for the given `pinned_vec` which is to be wrapped by a [`PinnedConcurrentCol`].
-    fn new_for_pinned_vec<T, P: PinnedVec<T>>(pinned_vec: &P) -> Self;
+    fn new_for_pinned_vec<T, P: PinnedVec<T>>(pinned_vec: &P) -> Self
+    where
+        T: Default;
 
     /// Evaluates and returns the `WritePermit` for a request to write to the `idx`-th position of the given `col`.
     ///
@@ -20,6 +22,7 @@ where
     /// This will be paired up with the `release_growth_handle` method, which will be called immediately after the allocation is completed.
     fn write_permit<T, P, S>(&self, col: &PinnedConcurrentCol<T, P, S>, idx: usize) -> WritePermit
     where
+        T: Default,
         P: PinnedVec<T>,
         S: ConcurrentState;
 
@@ -31,6 +34,7 @@ where
         num_items: usize,
     ) -> WritePermit
     where
+        T: Default,
         P: PinnedVec<T>,
         S: ConcurrentState,
     {
@@ -53,6 +57,7 @@ where
         pinned_vec: &P,
     ) -> String
     where
+        T: Default,
         P: PinnedVec<T>,
     {
         "PinnedVec".to_string()

--- a/tests/state.rs
+++ b/tests/state.rs
@@ -29,6 +29,7 @@ impl ConcurrentState for MyConState {
 
     fn write_permit<T, P, S>(&self, col: &PinnedConcurrentCol<T, P, S>, idx: usize) -> WritePermit
     where
+        T: Default,
         P: PinnedVec<T>,
         S: ConcurrentState,
     {
@@ -46,6 +47,7 @@ impl ConcurrentState for MyConState {
         num_items: usize,
     ) -> WritePermit
     where
+        T: Default,
         P: PinnedVec<T>,
         S: ConcurrentState,
     {


### PR DESCRIPTION
In the prior version `write_n_items` method writes the elements one by one by using random access through indices of the pinned vector.

In this version, `write_n_items` method makes use of the `slices_mut` method of the pinned vector. This method returns an iterator to mutable slices for the target range. Note that in most relevant use cases this iterator will return only one slice. Writing is then through a loop over the slice which enables better performance optimizations due to explicit serial access.