### PR TITLE
fix/drop-of-bags-with-gaps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-concurrent-col"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A core data structure with a focus to enable high performance, possibly lock-free, concurrent collections using a PinnedVec as the underlying storage."

--- a/src/common_traits/debug.rs
+++ b/src/common_traits/debug.rs
@@ -4,7 +4,6 @@ use std::fmt::Debug;
 
 impl<T, P, S> Debug for PinnedConcurrentCol<T, P, S>
 where
-    T: Default,
     P: PinnedVec<T>,
     S: ConcurrentState + Debug,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ mod capacity;
 mod col;
 mod common_traits;
 mod errors;
+mod mem_state;
 mod new;
 mod state;
 mod write_permit;

--- a/src/mem_state.rs
+++ b/src/mem_state.rs
@@ -1,0 +1,4 @@
+pub(crate) enum VecDropState {
+    TakenOut,
+    ToBeDropped,
+}

--- a/src/new.rs
+++ b/src/new.rs
@@ -4,7 +4,6 @@ use orx_split_vec::{Doubling, Linear, Recursive, SplitVec};
 
 impl<T, S> PinnedConcurrentCol<T, SplitVec<T, Doubling>, S>
 where
-    T: Default,
     S: ConcurrentState,
 {
     /// Creates a new concurrent bag by creating and wrapping up a new `SplitVec<T, Doubling>` as the underlying storage.
@@ -15,7 +14,6 @@ where
 
 impl<T, S> PinnedConcurrentCol<T, SplitVec<T, Recursive>, S>
 where
-    T: Default,
     S: ConcurrentState,
 {
     /// Creates a new concurrent bag by creating and wrapping up a new `SplitVec<T, Recursive>` as the underlying storage.
@@ -26,7 +24,6 @@ where
 
 impl<T, S> PinnedConcurrentCol<T, SplitVec<T, Linear>, S>
 where
-    T: Default,
     S: ConcurrentState,
 {
     /// Creates a new concurrent bag by creating and wrapping up a new `SplitVec<T, Linear>` as the underlying storage.
@@ -52,7 +49,6 @@ where
 
 impl<T, S> PinnedConcurrentCol<T, FixedVec<T>, S>
 where
-    T: Default,
     S: ConcurrentState,
 {
     /// Creates a new concurrent bag by creating and wrapping up a new `FixedVec<T>` as the underlying storage.
@@ -72,7 +68,6 @@ where
 // from
 impl<T, P, S> From<P> for PinnedConcurrentCol<T, P, S>
 where
-    T: Default,
     P: PinnedVec<T>,
     S: ConcurrentState,
 {

--- a/src/state.rs
+++ b/src/state.rs
@@ -10,9 +10,7 @@ where
     fn zero_memory(&self) -> bool;
 
     /// Creates a new state for the given `pinned_vec` which is to be wrapped by a [`PinnedConcurrentCol`].
-    fn new_for_pinned_vec<T, P: PinnedVec<T>>(pinned_vec: &P) -> Self
-    where
-        T: Default;
+    fn new_for_pinned_vec<T, P: PinnedVec<T>>(pinned_vec: &P) -> Self;
 
     /// Evaluates and returns the `WritePermit` for a request to write to the `idx`-th position of the given `col`.
     ///
@@ -22,7 +20,6 @@ where
     /// This will be paired up with the `release_growth_handle` method, which will be called immediately after the allocation is completed.
     fn write_permit<T, P, S>(&self, col: &PinnedConcurrentCol<T, P, S>, idx: usize) -> WritePermit
     where
-        T: Default,
         P: PinnedVec<T>,
         S: ConcurrentState;
 
@@ -34,7 +31,6 @@ where
         num_items: usize,
     ) -> WritePermit
     where
-        T: Default,
         P: PinnedVec<T>,
         S: ConcurrentState,
     {
@@ -57,9 +53,12 @@ where
         pinned_vec: &P,
     ) -> String
     where
-        T: Default,
         P: PinnedVec<T>,
     {
         "PinnedVec".to_string()
     }
+
+    /// Tries to get the length of the underlying pinned vector which is written without a gap.
+    /// Returns `None` if it is not known with certainty.
+    fn try_get_no_gap_len(&self) -> Option<usize>;
 }

--- a/tests/state.rs
+++ b/tests/state.rs
@@ -29,7 +29,6 @@ impl ConcurrentState for MyConState {
 
     fn write_permit<T, P, S>(&self, col: &PinnedConcurrentCol<T, P, S>, idx: usize) -> WritePermit
     where
-        T: Default,
         P: PinnedVec<T>,
         S: ConcurrentState,
     {
@@ -47,7 +46,6 @@ impl ConcurrentState for MyConState {
         num_items: usize,
     ) -> WritePermit
     where
-        T: Default,
         P: PinnedVec<T>,
         S: ConcurrentState,
     {
@@ -64,6 +62,10 @@ impl ConcurrentState for MyConState {
     fn release_growth_handle(&self) {}
 
     fn update_after_write(&self, _: usize, _: usize) {}
+
+    fn try_get_no_gap_len(&self) -> Option<usize> {
+        None
+    }
 }
 
 #[test]


### PR DESCRIPTION
* `Drop` is implemented for `PinnedConcurrentCol`
  * Underlying pinned vector is wrapped with a `ManuallyDrop`
  * An `into_inner` call takes the pinned vector out of the manually drop wrapper and  returns it.
  * If the bag is dropped without an `into_inner` call, the drop method will try to make sure that the pinned vector does not contain gaps before dropping.
  * `try_get_no_gap_len` is added to the `State` trait for this purpose.
* `Default` requirement of elements is removed.