### PR TITLE
n_items_buffer_as_mut_slices is implemented

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-concurrent-col"
-version = "1.4.0"
+version = "1.5.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A core data structure with a focus to enable high performance, possibly lock-free, concurrent collections using a PinnedVec as the underlying storage."
@@ -10,9 +10,9 @@ keywords = ["concurrency", "bag", "data-structures", "atomic", "lock-free"]
 categories = ["data-structures", "concurrency", "rust-patterns"]
 
 [dependencies]
-orx-fixed-vec = "2.11"
-orx-pinned-vec = "2.11"
-orx-split-vec = "2.13"
+orx-fixed-vec = "2.12"
+orx-pinned-vec = "2.12"
+orx-split-vec = "2.14"
 
 [dev-dependencies]
 test-case = "3.3.1"


### PR DESCRIPTION
This unsafe method provides the mutable slices allowing the consumer to write into the reserved buffer efficiently.