### PR TITLE
fill_memory_with is required by the state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-concurrent-col"
-version = "2.2.0"
+version = "2.3.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A core data structure with a focus to enable high performance, possibly lock-free, concurrent collections using a PinnedVec as the underlying storage."
@@ -10,10 +10,10 @@ keywords = ["concurrency", "bag", "data-structures", "atomic", "lock-free"]
 categories = ["data-structures", "concurrency", "rust-patterns"]
 
 [dependencies]
-orx-pseudo-default = "1.2.0"
-orx-pinned-vec = "3.2.0"
-orx-fixed-vec = "3.2.0"
-orx-split-vec = "3.2.0"
+orx-pseudo-default = "1.2"
+orx-pinned-vec = "3.3"
+orx-fixed-vec = "3.3"
+orx-split-vec = "3.3"
 
 [dev-dependencies]
 test-case = "3.3.1"

--- a/src/common_traits/debug.rs
+++ b/src/common_traits/debug.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 impl<T, P, S> Debug for PinnedConcurrentCol<T, P, S>
 where
     P: ConcurrentPinnedVec<T>,
-    S: ConcurrentState + Debug,
+    S: ConcurrentState<T> + Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PinnedConcurrentCol")

--- a/src/new.rs
+++ b/src/new.rs
@@ -4,7 +4,7 @@ use orx_split_vec::{ConcurrentSplitVec, Doubling, Linear, SplitVec};
 
 impl<T, S> PinnedConcurrentCol<T, ConcurrentSplitVec<T, Doubling>, S>
 where
-    S: ConcurrentState,
+    S: ConcurrentState<T>,
 {
     /// Creates a new concurrent bag by creating and wrapping up a new `SplitVec<T, Doubling>` as the underlying storage.
     pub fn with_doubling_growth() -> Self {
@@ -14,7 +14,7 @@ where
 
 impl<T, S> PinnedConcurrentCol<T, ConcurrentSplitVec<T, Linear>, S>
 where
-    S: ConcurrentState,
+    S: ConcurrentState<T>,
 {
     /// Creates a new concurrent bag by creating and wrapping up a new `SplitVec<T, Linear>` as the underlying storage.
     ///
@@ -39,7 +39,7 @@ where
 
 impl<T, S> PinnedConcurrentCol<T, ConcurrentFixedVec<T>, S>
 where
-    S: ConcurrentState,
+    S: ConcurrentState<T>,
 {
     /// Creates a new concurrent bag by creating and wrapping up a new `FixedVec<T>` as the underlying storage.
     ///

--- a/tests/col.rs
+++ b/tests/col.rs
@@ -13,7 +13,7 @@ fn new_from_pinned() {
     let pinned_vec: SplitVec<String> = SplitVec::with_doubling_growth_and_fragments_capacity(32);
     let expected_state = MyConState::new_for_pinned_vec(&pinned_vec);
 
-    let col: PinnedConcurrentCol<_, _, MyConState> =
+    let col: PinnedConcurrentCol<_, _, MyConState<_>> =
         PinnedConcurrentCol::new_from_pinned(pinned_vec.clone());
 
     assert_eq!(col.state().initial_len, expected_state.initial_len);
@@ -31,7 +31,7 @@ fn into_inner() {
     vec.push("a".to_string());
     vec.push("b".to_string());
 
-    let col: PinnedConcurrentCol<_, _, MyConState> = PinnedConcurrentCol::new_from_pinned(vec);
+    let col: PinnedConcurrentCol<_, _, MyConState<_>> = PinnedConcurrentCol::new_from_pinned(vec);
 
     let vec_back = unsafe { col.into_inner(2) };
     assert_eq!(&vec_back, &["a".to_string(), "b".to_string()]);
@@ -47,7 +47,7 @@ fn iter<P: IntoConcurrentPinnedVec<String>>(mut vec: P) {
         vec.push(i.to_string());
     }
 
-    let col: PinnedConcurrentCol<_, _, MyConState> = PinnedConcurrentCol::new_from_pinned(vec);
+    let col: PinnedConcurrentCol<_, _, MyConState<_>> = PinnedConcurrentCol::new_from_pinned(vec);
 
     let iter = unsafe { col.iter(0) };
     assert_eq!(iter.count(), 0);
@@ -75,7 +75,7 @@ fn get<P: IntoConcurrentPinnedVec<String>>(mut vec: P) {
         vec.push(i.to_string());
     }
 
-    let col: PinnedConcurrentCol<_, _, MyConState> = PinnedConcurrentCol::new_from_pinned(vec);
+    let col: PinnedConcurrentCol<_, _, MyConState<_>> = PinnedConcurrentCol::new_from_pinned(vec);
 
     assert_eq!(unsafe { col.get(4) }, Some(&String::from("4")));
     assert_eq!(unsafe { col.get(186) }, Some(&String::from("186")));
@@ -97,7 +97,8 @@ fn get_mut<P: IntoConcurrentPinnedVec<String>>(mut vec: P) {
         vec.push(i.to_string());
     }
 
-    let mut col: PinnedConcurrentCol<_, _, MyConState> = PinnedConcurrentCol::new_from_pinned(vec);
+    let mut col: PinnedConcurrentCol<_, _, MyConState<_>> =
+        PinnedConcurrentCol::new_from_pinned(vec);
 
     let element42 = unsafe { col.get_mut(42) }.expect("is-some");
     *element42 = "x".to_string();
@@ -112,7 +113,7 @@ fn get_mut<P: IntoConcurrentPinnedVec<String>>(mut vec: P) {
     FixedVec::new(51)
 ])]
 fn can_reserve_maximum_capacity<P: IntoConcurrentPinnedVec<String>>(pinned_vec: P) {
-    let mut col: PinnedConcurrentCol<_, _, MyConState> =
+    let mut col: PinnedConcurrentCol<_, _, MyConState<_>> =
         PinnedConcurrentCol::new_from_pinned(pinned_vec);
 
     let max_cap = col.maximum_capacity();
@@ -133,7 +134,8 @@ fn clear<P: IntoConcurrentPinnedVec<String>>(mut vec: P) {
         vec.push(i.to_string());
     }
 
-    let mut col: PinnedConcurrentCol<_, _, MyConState> = PinnedConcurrentCol::new_from_pinned(vec);
+    let mut col: PinnedConcurrentCol<_, _, MyConState<_>> =
+        PinnedConcurrentCol::new_from_pinned(vec);
 
     assert_eq!(col.state().initial_len, 187);
     assert_eq!(col.capacity(), col.state().initial_cap);

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -13,14 +13,14 @@ fn debug_split_doubling() {
         vec.push(i);
     }
 
-    let col: PinnedConcurrentCol<_, _, MyConState> = PinnedConcurrentCol::new_from_pinned(vec);
+    let col: PinnedConcurrentCol<_, _, MyConState<_>> = PinnedConcurrentCol::new_from_pinned(vec);
 
     for i in 187..300 {
         unsafe { col.write(i, i) };
     }
 
     let debug = format!("{:?}", col);
-    let expected = "PinnedConcurrentCol { state: MyConState { initial_len: 187, initial_cap: 252, len: 187 }, capacity: 508, maximum_capacity: 17179869180 }";
+    let expected = "PinnedConcurrentCol { state: MyConState { initial_len: 187, initial_cap: 252, len: 187, phantom: PhantomData<usize> }, capacity: 508, maximum_capacity: 17179869180 }";
 
     assert_eq!(debug, expected);
 }
@@ -32,14 +32,14 @@ fn debug_split_linear() {
         vec.push(i);
     }
 
-    let col: PinnedConcurrentCol<_, _, MyConState> = PinnedConcurrentCol::new_from_pinned(vec);
+    let col: PinnedConcurrentCol<_, _, MyConState<_>> = PinnedConcurrentCol::new_from_pinned(vec);
 
     for i in 187..1500 {
         unsafe { col.write(i, i) };
     }
 
     let debug = format!("{:?}", col);
-    let expected = "PinnedConcurrentCol { state: MyConState { initial_len: 187, initial_cap: 1024, len: 187 }, capacity: 2048, maximum_capacity: 32768 }";
+    let expected = "PinnedConcurrentCol { state: MyConState { initial_len: 187, initial_cap: 1024, len: 187, phantom: PhantomData<usize> }, capacity: 2048, maximum_capacity: 32768 }";
 
     assert_eq!(debug, expected);
 }
@@ -51,14 +51,14 @@ fn debug_fixed() {
         vec.push(i);
     }
 
-    let col: PinnedConcurrentCol<_, _, MyConState> = PinnedConcurrentCol::new_from_pinned(vec);
+    let col: PinnedConcurrentCol<_, _, MyConState<_>> = PinnedConcurrentCol::new_from_pinned(vec);
 
     for i in 187..300 {
         unsafe { col.write(i, i) };
     }
 
     let debug = format!("{:?}", col);
-    let expected = "PinnedConcurrentCol { state: MyConState { initial_len: 187, initial_cap: 333, len: 187 }, capacity: 333, maximum_capacity: 333 }";
+    let expected = "PinnedConcurrentCol { state: MyConState { initial_len: 187, initial_cap: 333, len: 187, phantom: PhantomData<usize> }, capacity: 333, maximum_capacity: 333 }";
 
     assert_eq!(debug, expected);
 }

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -8,7 +8,7 @@ use state::MyConState;
 
 #[test]
 fn with_doubling_growth() {
-    let col: PinnedConcurrentCol<String, _, MyConState> =
+    let col: PinnedConcurrentCol<String, _, MyConState<_>> =
         PinnedConcurrentCol::with_doubling_growth();
 
     assert_eq!(col.capacity(), 4);
@@ -19,7 +19,7 @@ fn with_doubling_growth() {
 
 #[test]
 fn with_linear_growth() {
-    let col: PinnedConcurrentCol<String, _, MyConState> =
+    let col: PinnedConcurrentCol<String, _, MyConState<_>> =
         PinnedConcurrentCol::with_linear_growth(4, 10);
 
     assert_eq!(col.capacity(), 2usize.pow(4));
@@ -30,7 +30,7 @@ fn with_linear_growth() {
 
 #[test]
 fn with_fixed_capacity() {
-    let col: PinnedConcurrentCol<String, _, MyConState> =
+    let col: PinnedConcurrentCol<String, _, MyConState<_>> =
         PinnedConcurrentCol::with_fixed_capacity(5648);
 
     assert_eq!(col.capacity(), 5648);
@@ -44,7 +44,7 @@ fn from() {
     fn validate<P: IntoConcurrentPinnedVec<String>>(pinned_vec: P) {
         let max_cap = pinned_vec.capacity_state().maximum_concurrent_capacity();
         let expected_con_state = MyConState::new_for_pinned_vec(&pinned_vec);
-        let col: PinnedConcurrentCol<_, _, MyConState> =
+        let col: PinnedConcurrentCol<_, _, MyConState<_>> =
             PinnedConcurrentCol::new_from_pinned(pinned_vec);
 
         assert_eq!(col.capacity(), expected_con_state.initial_cap);

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -21,7 +21,7 @@ fn write_drop_col<P: IntoConcurrentPinnedVec<String>>(mut vec: P) {
         vec.push(idx.to_string());
     }
 
-    let col: PinnedConcurrentCol<_, _, MyConState> = PinnedConcurrentCol::new_from_pinned(vec);
+    let col: PinnedConcurrentCol<_, _, MyConState<_>> = PinnedConcurrentCol::new_from_pinned(vec);
 
     for idx in len1..len2 {
         unsafe { col.write(idx, idx.to_string()) };
@@ -48,7 +48,7 @@ fn write_drop_vec<P: IntoConcurrentPinnedVec<String>>(mut vec: P) {
         vec.push(idx.to_string());
     }
 
-    let col: PinnedConcurrentCol<_, _, MyConState> = PinnedConcurrentCol::new_from_pinned(vec);
+    let col: PinnedConcurrentCol<_, _, MyConState<_>> = PinnedConcurrentCol::new_from_pinned(vec);
 
     for idx in len1..len2 {
         unsafe { col.write(idx, idx.to_string()) };

--- a/tests/write_n_items.rs
+++ b/tests/write_n_items.rs
@@ -21,7 +21,7 @@ fn write_n_item_drop_col<P: IntoConcurrentPinnedVec<String>>(mut vec: P, n: usiz
         vec.push(idx.to_string());
     }
 
-    let col: PinnedConcurrentCol<_, _, MyConState> = PinnedConcurrentCol::new_from_pinned(vec);
+    let col: PinnedConcurrentCol<_, _, MyConState<_>> = PinnedConcurrentCol::new_from_pinned(vec);
 
     for idx in (len1..len2).step_by(n) {
         let begin_idx = idx;
@@ -53,7 +53,7 @@ fn write_n_item_drop_vec<P: IntoConcurrentPinnedVec<String>>(mut vec: P, n: usiz
         vec.push(idx.to_string());
     }
 
-    let col: PinnedConcurrentCol<_, _, MyConState> = PinnedConcurrentCol::new_from_pinned(vec);
+    let col: PinnedConcurrentCol<_, _, MyConState<_>> = PinnedConcurrentCol::new_from_pinned(vec);
 
     for idx in (len1..len2).step_by(n) {
         let begin_idx = idx;


### PR DESCRIPTION
* `single_item_as_ref` is implemented to provide a reference of a single element, this is the counterpart of `n_items_buffer_as_slices` for one position.
* `fill_memory_with` method is required by the state. This is important for enabling data structures which always have an initialized valid state while growing concurrently. *