### PR TITLE
32-bit support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-concurrent-col"
-version = "2.3.0"
+version = "2.4.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A core data structure with a focus to enable high performance, possibly lock-free, concurrent collections using a PinnedVec as the underlying storage."
@@ -10,10 +10,10 @@ keywords = ["concurrency", "bag", "data-structures", "atomic", "lock-free"]
 categories = ["data-structures", "concurrency", "rust-patterns"]
 
 [dependencies]
-orx-pseudo-default = "1.2"
-orx-pinned-vec = "3.3"
-orx-fixed-vec = "3.3"
-orx-split-vec = "3.3"
+orx-pseudo-default = "1.4"
+orx-pinned-vec = "3.4"
+orx-fixed-vec = "3.4"
+orx-split-vec = "3.4"
 
 [dev-dependencies]
 test-case = "3.3.1"


### PR DESCRIPTION
Due to the downstream upgrade in SplitVec: https://github.com/orxfun/orx-split-vec/releases/tag/3.4.0