### PR TITLE
reserve initialized data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-concurrent-col"
-version = "2.5.0"
+version = "2.6.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A core data structure with a focus to enable high performance, possibly lock-free, concurrent collections using a PinnedVec as the underlying storage."
@@ -11,9 +11,9 @@ categories = ["data-structures", "concurrency", "rust-patterns"]
 
 [dependencies]
 orx-pseudo-default = "1.4"
-orx-pinned-vec = "3.6"
-orx-fixed-vec = "3.6"
-orx-split-vec = "3.6"
+orx-pinned-vec = "3.7"
+orx-fixed-vec = "3.7"
+orx-split-vec = "3.7"
 
 [dev-dependencies]
 test-case = "3.3.1"

--- a/src/col.rs
+++ b/src/col.rs
@@ -322,8 +322,18 @@ where
         current_len: usize,
         maximum_capacity: usize,
     ) -> usize {
-        self.con_pinned_vec
-            .reserve_maximum_concurrent_capacity(current_len, maximum_capacity)
+        match self.state.fill_memory_with() {
+            Some(fill_with) => self
+                .con_pinned_vec
+                .reserve_maximum_concurrent_capacity_fill_with(
+                    current_len,
+                    maximum_capacity,
+                    fill_with,
+                ),
+            None => self
+                .con_pinned_vec
+                .reserve_maximum_concurrent_capacity(current_len, maximum_capacity),
+        }
     }
 
     /// Writes the `value` to the `idx`-th position.

--- a/tests/col.rs
+++ b/tests/col.rs
@@ -1,5 +1,4 @@
 mod state;
-
 use orx_fixed_vec::FixedVec;
 use orx_pinned_concurrent_col::*;
 use orx_pinned_vec::PinnedVec;
@@ -11,7 +10,7 @@ use test_case::test_matrix;
 #[test]
 fn new_from_pinned() {
     let pinned_vec: SplitVec<String> = SplitVec::with_doubling_growth_and_fragments_capacity(32);
-    let expected_state = MyConState::new_for_pinned_vec(&pinned_vec);
+    let expected_state = MyConState::<_>::new_for_pinned_vec(&pinned_vec);
 
     let col: PinnedConcurrentCol<_, _, MyConState<_>> =
         PinnedConcurrentCol::new_from_pinned(pinned_vec.clone());

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -1,5 +1,4 @@
 mod state;
-
 use orx_fixed_vec::FixedVec;
 use orx_pinned_concurrent_col::*;
 use orx_pinned_vec::{IntoConcurrentPinnedVec, PinnedVec};
@@ -43,7 +42,7 @@ fn with_fixed_capacity() {
 fn from() {
     fn validate<P: IntoConcurrentPinnedVec<String>>(pinned_vec: P) {
         let max_cap = pinned_vec.capacity_state().maximum_concurrent_capacity();
-        let expected_con_state = MyConState::new_for_pinned_vec(&pinned_vec);
+        let expected_con_state = MyConState::<_>::new_for_pinned_vec(&pinned_vec);
         let col: PinnedConcurrentCol<_, _, MyConState<_>> =
             PinnedConcurrentCol::new_from_pinned(pinned_vec);
 

--- a/tests/new_filled_with.rs
+++ b/tests/new_filled_with.rs
@@ -1,0 +1,53 @@
+mod state;
+use orx_fixed_vec::FixedVec;
+use orx_pinned_concurrent_col::*;
+use orx_split_vec::SplitVec;
+use prelude::IntoConcurrentPinnedVec;
+use state::{MyConState, MyConStateFilled};
+use test_case::test_matrix;
+
+#[test_matrix([
+    FixedVec::new(222),
+    SplitVec::with_doubling_growth_and_fragments_capacity(16),
+    SplitVec::with_linear_growth_and_fragments_capacity(10, 33)
+])]
+fn new_no_fill<P: IntoConcurrentPinnedVec<String>>(mut vec: P) {
+    vec.push("first".to_string());
+
+    let initial_len = vec.len();
+    let initial_capacity = vec.capacity();
+
+    let col: PinnedConcurrentCol<_, _, MyConState<_>> = PinnedConcurrentCol::new_from_pinned(vec);
+
+    let vec = unsafe { col.into_inner(initial_len) };
+
+    assert_eq!(vec.len(), 1);
+    assert_eq!(vec.capacity(), initial_capacity);
+    assert_eq!(&vec[0], &"first".to_string());
+}
+
+#[test_matrix([
+    FixedVec::new(222),
+    SplitVec::with_doubling_growth_and_fragments_capacity(16),
+    SplitVec::with_linear_growth_and_fragments_capacity(10, 33)
+])]
+fn new_fill_with<P: IntoConcurrentPinnedVec<String>>(mut vec: P) {
+    vec.push("first".to_string());
+
+    let initial_capacity = vec.capacity();
+
+    let col: PinnedConcurrentCol<_, _, MyConStateFilled<_>> =
+        PinnedConcurrentCol::new_from_pinned(vec);
+
+    let vec = unsafe { col.into_inner(initial_capacity) };
+
+    assert_eq!(vec.len(), initial_capacity);
+    assert_eq!(vec.capacity(), initial_capacity);
+    assert_eq!(&vec[0], &"first".to_string());
+    assert_eq!(
+        vec.into_iter().skip(1).collect::<Vec<_>>(),
+        (1..initial_capacity)
+            .map(|_| String::default())
+            .collect::<Vec<_>>()
+    );
+}

--- a/tests/reserve.rs
+++ b/tests/reserve.rs
@@ -1,0 +1,51 @@
+mod state;
+use orx_fixed_vec::FixedVec;
+use orx_pinned_concurrent_col::*;
+use orx_split_vec::SplitVec;
+use prelude::IntoConcurrentPinnedVec;
+use state::{MyConState, MyConStateFilled};
+use test_case::test_matrix;
+
+#[test_matrix([
+    FixedVec::new(222),
+    SplitVec::with_doubling_growth_and_fragments_capacity(16),
+    SplitVec::with_linear_growth_and_fragments_capacity(10, 33)
+])]
+fn reserve<P: IntoConcurrentPinnedVec<String>>(mut vec: P) {
+    vec.push("first".to_string());
+
+    let initial_capacity = vec.capacity();
+
+    let mut col: PinnedConcurrentCol<_, _, MyConState<_>> =
+        PinnedConcurrentCol::new_from_pinned(vec);
+    let max_cap = col.maximum_capacity();
+
+    assert_eq!(col.capacity(), initial_capacity);
+
+    let new_capacity = unsafe { col.reserve_maximum_capacity(1, max_cap + 1) };
+
+    assert!(new_capacity >= max_cap + 1);
+    assert!(col.capacity() >= initial_capacity);
+}
+
+#[test_matrix([
+    FixedVec::new(222),
+    SplitVec::with_doubling_growth_and_fragments_capacity(16),
+    SplitVec::with_linear_growth_and_fragments_capacity(10, 33)
+])]
+fn reserve_fill_with<P: IntoConcurrentPinnedVec<String>>(mut vec: P) {
+    vec.push("first".to_string());
+
+    let initial_capacity = vec.capacity();
+
+    let mut col: PinnedConcurrentCol<_, _, MyConStateFilled<_>> =
+        PinnedConcurrentCol::new_from_pinned(vec);
+    let max_cap = col.maximum_capacity();
+
+    assert_eq!(col.capacity(), initial_capacity);
+
+    let new_capacity = unsafe { col.reserve_maximum_capacity(1, max_cap + 1) };
+
+    assert!(new_capacity >= max_cap + 1);
+    assert!(col.capacity() >= initial_capacity);
+}

--- a/tests/state.rs
+++ b/tests/state.rs
@@ -94,3 +94,94 @@ impl<T> ConcurrentState<T> for MyConState<T> {
         Some(self.len())
     }
 }
+
+// FILL-WITH
+
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct MyConStateFilled<T: Default> {
+    pub initial_len: usize,
+    pub initial_cap: usize,
+    pub len: AtomicUsize,
+    phantom: PhantomData<T>,
+}
+
+impl<T: Default> MyConStateFilled<T> {
+    pub fn new(initial_len: usize, initial_cap: usize) -> Self {
+        Self {
+            initial_len,
+            initial_cap,
+            len: initial_len.into(),
+            phantom: Default::default(),
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn len(&self) -> usize {
+        self.len.load(atomic::Ordering::Relaxed)
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn fetch_increment_len(&self, increment_by: usize) -> usize {
+        self.len.fetch_add(increment_by, atomic::Ordering::AcqRel)
+    }
+
+    #[allow(dead_code)]
+    pub fn set_final_len(&self, len: usize) {
+        self.len.store(len, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+impl<T: Default> ConcurrentState<T> for MyConStateFilled<T> {
+    fn fill_memory_with(&self) -> Option<fn() -> T> {
+        Some(|| Default::default())
+    }
+
+    fn new_for_pinned_vec<P: PinnedVec<T>>(pinned_vec: &P) -> Self {
+        Self::new(pinned_vec.len(), pinned_vec.capacity())
+    }
+
+    fn new_for_con_pinned_vec<P: ConcurrentPinnedVec<T>>(con_pinned_vec: &P, len: usize) -> Self {
+        Self::new(len, con_pinned_vec.capacity())
+    }
+
+    fn write_permit<P>(&self, col: &PinnedConcurrentCol<T, P, Self>, idx: usize) -> WritePermit
+    where
+        P: ConcurrentPinnedVec<T>,
+    {
+        let capacity = col.capacity();
+
+        match idx.cmp(&capacity) {
+            Ordering::Less => WritePermit::JustWrite,
+            Ordering::Equal => WritePermit::GrowThenWrite,
+            Ordering::Greater => WritePermit::Spin,
+        }
+    }
+
+    fn write_permit_n_items<P>(
+        &self,
+        col: &PinnedConcurrentCol<T, P, Self>,
+        begin_idx: usize,
+        num_items: usize,
+    ) -> WritePermit
+    where
+        P: ConcurrentPinnedVec<T>,
+    {
+        let capacity = col.capacity();
+        let last_idx = begin_idx + num_items - 1;
+
+        match (begin_idx.cmp(&capacity), last_idx.cmp(&capacity)) {
+            (_, std::cmp::Ordering::Less) => WritePermit::JustWrite,
+            (std::cmp::Ordering::Greater, _) => WritePermit::Spin,
+            _ => WritePermit::GrowThenWrite,
+        }
+    }
+
+    fn release_growth_handle(&self) {}
+
+    fn update_after_write(&self, _: usize, _: usize) {}
+
+    fn try_get_no_gap_len(&self) -> Option<usize> {
+        Some(self.len())
+    }
+}


### PR DESCRIPTION
* Whenever a concurrent state requires initialized storage, calls to the reserve maximum capacity method also makes sure that the new allocation (if any) is initialized.
* Reserve and initialization tests are extended.