### PR TITLE
iter_over_range

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-concurrent-col"
-version = "2.7.0"
+version = "2.8.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A core data structure with a focus to enable high performance, possibly lock-free, concurrent collections using a PinnedVec as the underlying storage."
@@ -11,9 +11,9 @@ categories = ["data-structures", "concurrency", "rust-patterns", "no-std"]
 
 [dependencies]
 orx-pseudo-default = { version = "1.4", default-features = false }
-orx-pinned-vec = "3.8"
-orx-fixed-vec = "3.8"
-orx-split-vec = "3.8"
+orx-pinned-vec = "3.10"
+orx-fixed-vec = "3.10"
+orx-split-vec = "3.10"
 
 [dev-dependencies]
 test-case = "3.3.1"


### PR DESCRIPTION
`iter_over_range` method is provided.

At one hand, `vec.iter_over_range(a..b)` is equivalent to `vec.iter().skip(a).take(b - a)`. However, the latter requires `a` unnecessary `next` calls. Since all pinned vectors provide random access to elements, the objective of `iter_over_range` is to directly jump to `a` and create an iterator from this point on, and hence, avoiding the unnecessary iterations at the beginning.