### PR TITLE
V3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ categories = ["data-structures", "concurrency", "rust-patterns", "no-std"]
 
 [dependencies]
 orx-pseudo-default = { version = "2.1.0", default-features = false }
-orx-pinned-vec = { git = "https://github.com/orxfun/orx-pinned-vec", branch = "v4", default-features = false }
-orx-fixed-vec = { git = "https://github.com/orxfun/orx-fixed-vec", branch = "v4", default-features = false }
-orx-split-vec = { git = "https://github.com/orxfun/orx-split-vec", branch = "v4", default-features = false }
+orx-pinned-vec = { version = "4.0.0", default-features = false }
+orx-fixed-vec = { version = "4.0.0", default-features = false }
+orx-split-vec = { version = "4.0.0", default-features = false }
 
 [dev-dependencies]
 test-case = "3.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ categories = ["data-structures", "concurrency", "rust-patterns", "no-std"]
 
 [dependencies]
 orx-pseudo-default = { version = "2.1.0", default-features = false }
-orx-pinned-vec = { version = "3.21.0", default-features = false }
-orx-fixed-vec = { version = "3.22.0", default-features = false }
-orx-split-vec = { version = "3.22.0", default-features = false }
+orx-pinned-vec = { git = "https://github.com/orxfun/orx-pinned-vec", branch = "v4", default-features = false }
+orx-fixed-vec = { git = "https://github.com/orxfun/orx-fixed-vec", branch = "v4", default-features = false }
+orx-split-vec = { git = "https://github.com/orxfun/orx-split-vec", branch = "v4", default-features = false }
 
 [dev-dependencies]
 test-case = "3.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-concurrent-col"
-version = "2.18.0"
+version = "3.0.0"
 edition = "2024"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A core data structure with a focus to enable high performance, possibly lock-free, concurrent collections using a PinnedVec as the underlying storage."

--- a/src/col.rs
+++ b/src/col.rs
@@ -608,12 +608,12 @@ where
         self.state = S::new_for_con_pinned_vec(&self.con_pinned_vec, 0);
     }
 
-    #[inline(always)]
     /// Returns a mutable reference to the element at the index-th position.
     ///
     /// # Safety
     ///
     /// Reading the pointer before writing its value will result in UB.
+    #[inline(always)]
     pub unsafe fn ptr_mut(&self, idx: usize) -> *mut T {
         unsafe { self.con_pinned_vec.get_ptr_mut(idx) }
     }

--- a/src/col.rs
+++ b/src/col.rs
@@ -607,6 +607,16 @@ where
         unsafe { self.con_pinned_vec.clear(prior_len) };
         self.state = S::new_for_con_pinned_vec(&self.con_pinned_vec, 0);
     }
+
+    #[inline(always)]
+    /// Returns a mutable reference to the element at the index-th position.
+    ///
+    /// # Safety
+    ///
+    /// Reading the pointer before writing its value will result in UB.
+    pub unsafe fn ptr_mut(&self, idx: usize) -> *mut T {
+        unsafe { self.con_pinned_vec.get_ptr_mut(idx) }
+    }
 }
 
 // HELPERS

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
     clippy::missing_panics_doc,
     clippy::todo
 )]
+#![cfg_attr(test, allow(clippy::unwrap_in_result, clippy::unwrap_used))]
 #![no_std]
 
 extern crate alloc;

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,4 @@
-use crate::{write_permit::WritePermit, PinnedConcurrentCol};
+use crate::{PinnedConcurrentCol, write_permit::WritePermit};
 use alloc::string::{String, ToString};
 use orx_pinned_vec::{ConcurrentPinnedVec, PinnedVec};
 

--- a/tests/reserve.rs
+++ b/tests/reserve.rs
@@ -24,7 +24,7 @@ fn reserve<P: IntoConcurrentPinnedVec<String>>(mut vec: P) {
 
     let new_capacity = unsafe { col.reserve_maximum_capacity(1, max_cap + 1) };
 
-    assert!(new_capacity >= max_cap + 1);
+    assert!(new_capacity > max_cap);
     assert!(col.capacity() >= initial_capacity);
 }
 
@@ -46,6 +46,6 @@ fn reserve_fill_with<P: IntoConcurrentPinnedVec<String>>(mut vec: P) {
 
     let new_capacity = unsafe { col.reserve_maximum_capacity(1, max_cap + 1) };
 
-    assert!(new_capacity >= max_cap + 1);
+    assert!(new_capacity > max_cap);
     assert!(col.capacity() >= initial_capacity);
 }


### PR DESCRIPTION
# Summary

* Depends on v4 pinned vectors
* Introduces `ptr_mut`
* Extends test coverage
